### PR TITLE
Bacula 5 on RHEL

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -45,14 +45,6 @@ class bacula::client(
     ensure => present,
   }
 
-  $plugin_dir = $::operatingsystem ? {
-    /(?i:RedHat|CentOS|Scientific)/ => $::architecture ? {
-      x86_64  => '/usr/lib64/bacula',
-      default => '/usr/lib/bacula',
-    },
-    default => '/usr/lib/bacula'
-  }
-
   file { '/etc/bacula/bacula-fd.conf':
     ensure  => file,
     owner   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,4 +59,12 @@ class bacula::params {
     /(Debian|Ubuntu)/ => 'bacula-sd-sqlite',
     default           => 'bacula-storage-sqlite',
   }
+  $client_plugin_dir           = $::operatingsystem ? {
+    /(?i:RedHat|CentOS|Scientific)/ => $::architecture ? {
+      x86_64  => '/usr/lib64/bacula',
+      default => '/usr/lib/bacula',
+    },
+    default => '/usr/lib/bacula'
+  }
+
 }

--- a/templates/bacula-fd.conf.erb
+++ b/templates/bacula-fd.conf.erb
@@ -14,7 +14,7 @@ Director {
 FileDaemon {
   Name = "<%= hostname.split('.').first -%>"
   Working Directory = /var/lib/bacula
-  Plugin Directory = <%= plugin_dir %>
+  Plugin Directory = <%= scope.lookupvar('bacula::params::client_plugin_dir') %>
   PID Directory = /var/run/bacula
   Maximum Concurrent Jobs = 3
 }


### PR DESCRIPTION
Hey,

On RHEL I use a repo that's maintained by a fedoraguy to get a non-ancient Bacula on RHEL5.

But this deviates  in regards to the plugin directory.

Would it make sense to

a) Leave out the plugin directory altogether.
b) Provide a 'manage_repo => true' option like puppet-percona (https://github.com/arioch/puppet-percona/blob/master/manifests/init.pp). I do:
  require common
  case $operatingsystem {
    'debian','ubuntu','mint': {
    }
    'redhat','centos','scientific': {
      yum::managed_yumrepo { epel-bacula:
        descr          => 'Bacula backports from rawhide',
        baseurl        => "http://repos.fedorapeople.org/repos/slaanesh/bacula/epel-$common::osver/\$basearch",
        enabled        => 1,
        gpgcheck       => 1,
        failovermethod => 'priority',
        gpgkey         => 'http://repos.fedorapeople.org/repos/slaanesh/bacula/RPM-GPG-KEY-slaanesh',
        priority       => 10,
        before         => Class['bacula'],
      }
    }
  }
c) Do nothing
d) All of the above?
