### PR TITLE
set params::validate default value of plugin_dir to undef.

### DIFF
--- a/manifests/params/validate.pp
+++ b/manifests/params/validate.pp
@@ -47,7 +47,7 @@ class bacula::params::validate (
   $manage_db             = '',
   $manage_db_tables      = '',
   $manage_logwatch       = '',
-  $plugin_dir            = '',
+  $plugin_dir            = undef,
   $storage_default_mount = '',
   $storage_server        = '',
   $tls_allowed_cn        = '',


### PR DESCRIPTION
Without this patch the bacula class's default value of undef, will not be used, since undef does not overwrite a parameter.
Thus the params::validate default value for plugin_dir will be used, which is ''.
This causes the validation to fail since '' is not a valid and absolute path.
To fix this behaviour, the default value for plugin_dir within the params::validate class should also be undef, to work
with the != undef condition within the class.
The error will be triggered if a bacula class is created without setting the plugin_dir argument.

The resulting error message is:
valuation Error: Error while evaluating a Function Call,  is not an absolute path.