### PR TITLE
Use type3x to maintain 3.x and 4.x compat

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -193,7 +193,7 @@ define bacula::client::config (
   }
 
   if $run_scripts {
-    case type($run_scripts) {
+    case type3x($run_scripts) {
       'array' : {
         # TODO figure out how to validate each item in the array is a hash.
         $run_scripts_real = $run_scripts


### PR DESCRIPTION
Works around:

https://tickets.puppetlabs.com/browse/MODULES-1473

``` puppet
2016-03-25 13:07:51,484 ERROR [puppet-server] Puppet Illegal expression. A Reserved Word 'type' is unacceptable as function name in a Function Call
2016-03-25 13:07:51,484 ERROR [puppet-server] Puppet Use of reserved word: type, must be quoted if intended to be a String value 
2016-03-25 13:07:51,486 ERROR [puppet-server] Puppet Found 2 errors. Giving up
```
